### PR TITLE
Implement backend logic for chat creation

### DIFF
--- a/src/components/ChatPage/ChatDisplay.tsx
+++ b/src/components/ChatPage/ChatDisplay.tsx
@@ -28,22 +28,23 @@ export function ChatDisplay(props: { chatID: string }) {
   const [message, setMessage] = useState('');
   const [placeholder, setPlaceholder] = useState('Ask me any question');
 
-useEffect(() => {
-  const fetchChatHistory = async () => {
-    try {
-      const instance = await ChatHistory.loadFromFirebase(1, "title");
-      setChatInstance(instance);
-      setMessages(instance.getHistory());
+  useEffect(() => {
+    const fetchChatHistory = async () => {
+      try {
+        const chatIdNum = parseInt(props.chatID);
+        const instance = await ChatHistory.loadFromFirebase(chatIdNum, "title");
+        setChatInstance(instance);
+        setMessages(instance.getHistory());
 
-      const chat: Chat | undefined = chatData.chats.find((c: Chat) => c.chatID === props.chatID); 
-      if (chat) setMemoryID(chat.memoryID);
-    } catch (err) {
-      console.error("Failed to load chat history:", err);
-      setMessages([]);
-    } finally {
-      setIsLoadingChatHistory(false);
-    }
-  };
+        const chat: Chat | undefined = chatData.chats.find((c: Chat) => c.chatID === props.chatID);
+        if (chat) setMemoryID(chat.memoryID);
+      } catch (err) {
+        console.error("Failed to load chat history:", err);
+        setMessages([]);
+      } finally {
+        setIsLoadingChatHistory(false);
+      }
+    };
 
     fetchChatHistory();
   }, [props.chatID]);
@@ -52,14 +53,14 @@ useEffect(() => {
     return <text className="centered-text">Loading chat history...</text>;
   } // newly added
 
-  const lastIndex : number = (messages.length)-1
- 
+  const lastIndex: number = (messages.length) - 1
+
 
   const onSend = useCallback(async () => {
     if (isLoadingChatHistory || !chatInstance) {
       return;
     }
-    
+
     if (!message.trim()) {
       setPlaceholder('⚠️ Empty messages are not allowed');
       return;
@@ -89,10 +90,10 @@ useEffect(() => {
       const reply =
         data?.candidates?.[0]?.content?.parts?.[0]?.text ||
         'No response from Gemini';
-    
+
       chatInstance.addModelMessage(reply);
       setMessages([...chatInstance.getHistory()]); // refresh UI
-      
+
       await chatInstance.saveToFirebase();
 
       setMessage('');
@@ -107,40 +108,40 @@ useEffect(() => {
       <NavBar />
       <MemoryBar memoryID={memoryID} setMemoryID={setMemoryID} />
       <view className="dialog-display-and-input">
-        <list 
-        className="dialog-display"
-        scroll-orientation="vertical"
-        initial-scroll-index={lastIndex}
-      >
-        {messages.length === 0 ? (
-          <list-item item-key="empty">
-            <text className="centered-text">What can I help with</text>
-          </list-item>
-        ) : (
-          messages.map((msg: ChatEntry, index) => (
-            <list-item 
-              key={index}
-              item-key={index.toString()}
-              className="dialog-list-item"
-            >
-              {msg.role === "user" ? (
-                <UserChatBubble text={msg.parts[0].text} />
-              ) : (
-                <AssistantChatBubble 
-                  text={msg.parts[0].text} 
-                  setIsReplying={setIsReplying} 
-                  setReplyMessageText={setReplyMessageText}/>
-              )}
+        <list
+          className="dialog-display"
+          scroll-orientation="vertical"
+          initial-scroll-index={lastIndex}
+        >
+          {messages.length === 0 ? (
+            <list-item item-key="empty">
+              <text className="centered-text">What can I help with</text>
             </list-item>
-          ))
-        )}
+          ) : (
+            messages.map((msg: ChatEntry, index) => (
+              <list-item
+                key={index}
+                item-key={index.toString()}
+                className="dialog-list-item"
+              >
+                {msg.role === "user" ? (
+                  <UserChatBubble text={msg.parts[0].text} />
+                ) : (
+                  <AssistantChatBubble
+                    text={msg.parts[0].text}
+                    setIsReplying={setIsReplying}
+                    setReplyMessageText={setReplyMessageText} />
+                )}
+              </list-item>
+            ))
+          )}
         </list>
         {/* Let the optional text only show the first five line and scrollable*/}
         {isReplying && (
           <view className="optional-reply-bar">
             <text className="optional-text">{replyMessageText}</text>
-            <image 
-              src={CrossIcon} 
+            <image
+              src={CrossIcon}
               className="close-reply-icon"
               bindtap={() => {
                 setIsReplying(false);
@@ -163,7 +164,7 @@ useEffect(() => {
           </view>
         </view>
 
-        
+
       </view>
     </view>
   );

--- a/src/components/ChatPage/ChatDisplay.tsx
+++ b/src/components/ChatPage/ChatDisplay.tsx
@@ -40,9 +40,10 @@ export function ChatDisplay(props: { chatID: string }) {
     const fetchChatHistory = async () => {
       try {
         const chatIdNum = parseInt(props.chatID);
-        const instance = await ChatHistory.loadFromFirebase(chatIdNum, "title");
-        setChatInstance(instance);
-        setMessages(instance.getHistory());
+        const chatInstance = await ChatHistory.loadFromFirebase(chatIdNum, "title");
+        setChatInstance(chatInstance);
+        setMessages(chatInstance.getHistory());
+        setMemoryID(chatInstance.getMemory().id);
 
         const chat: Chat | undefined = chatData.chats.find((c: Chat) => c.chatID === props.chatID);
         if (chat) setMemoryID(chat.memoryID);

--- a/src/components/ChatSession/ChatHistory.ts
+++ b/src/components/ChatSession/ChatHistory.ts
@@ -76,7 +76,7 @@ export default class ChatHistory {
   return [...memoryEntries, ...this.history];
   }
 
-  async saveGlobalCounter(count: number) {
+  static async saveGlobalCounter(count: number) {
     const res = await fetch(`${FIREBASE_DB}/global_counter.json`, {
       method: 'PUT', // PUT overwrites the value
       headers: { 'Content-Type': 'application/json' },
@@ -118,24 +118,24 @@ export default class ChatHistory {
   }
 
   // // Add this method inside your ChatHistory class
-  // static async getGlobalCounter(): Promise<number> {
-  //   try {
-  //     const res = await fetch(`${FIREBASE_DB}/global_counter.json`);
+  static async getGlobalCounter(): Promise<number> {
+    try {
+      const res = await fetch(`${FIREBASE_DB}/global_counter.json`);
       
-  //     // Handle Firebase's "null" response for non-existing data
-  //     if (res.status === 200) {
-  //       const data = await res.json();
-  //       return data === null ? 0 : data;
-  //     }
+      // Handle Firebase's "null" response for non-existing data
+      if (res.status === 200) {
+        const data = await res.json();
+        return data === null ? 0 : data;
+      }
       
-  //     // Handle actual errors (404, network issues, etc)
-  //     console.error('Failed to fetch global counter', res.status, await res.text());
-  //     return 0;
-  //   } catch (error) {
-  //     console.error('Network error fetching global counter', error);
-  //     return 0;
-  //   }
-  // }
+      // Handle actual errors (404, network issues, etc)
+      console.error('Failed to fetch global counter', res.status, await res.text());
+      return 0;
+    } catch (error) {
+      console.error('Network error fetching global counter', error);
+      return 0;
+    }
+  }
 
 
 }

--- a/src/components/ChatSession/ChatHistory.ts
+++ b/src/components/ChatSession/ChatHistory.ts
@@ -12,9 +12,15 @@ export interface ChatEntry {
   parts: ChatPart[];
 }
 
+export interface MemoryEntry {
+  id: string;
+  title: string;
+  value: string;
+}
+
 export default class ChatHistory {
 
-  constructor(chatid: number, chattitle: string = "Untitled Chat", history: ChatEntry[] = [], memory: Record<string, string> = {}) {
+  constructor(chatid: number, chattitle: string = "Untitled Chat", history: ChatEntry[] = [], memory: MemoryEntry = {id: "", title: "", value: ""}) {
     this.chatid = chatid;
     this.chattitle = chattitle;
     this.history = history;
@@ -26,7 +32,7 @@ export default class ChatHistory {
   private chatid: number = -1;
   private chattitle: string = '';
   private history: ChatEntry[] = [];
-  private memory: Record<string, string> = {"1": "[This is for your background information, you do not have to explcily reply it, treat it as your memory about me] mood: happy, name: xingye, home: Mars"};
+  private memory: MemoryEntry = { id: "0", title: "[This is for your background information, you do not have to explcily reply it, treat it as your memory about me] S", value: "S is sweet" };
   private replyMessage: ChatEntry = { role: 'user', parts: [{ text: '' }] };
 
   setReplyMessage(message: string) {
@@ -58,16 +64,14 @@ export default class ChatHistory {
   }
 
   //   Memory Management
-  setMemory(key: string, value: string) {
-    this.memory[key] = "[This is for your background information, you do not have to explcily reply it, treat it as your memory about me] " + value;
-  }
-
-  deleteMemory(key: string) {
-    delete this.memory[key];
+  setMemory(id: string, title: string, value: string) {
+    this.memory["id"] = id;
+    this.memory["title"] = "[This is for your background information, you do not have to explcily reply it, treat it as your memory about me] " + title;
+    this.memory["value"] = value;
   }
 
   clearMemory() {
-    this.memory = {};
+    this.memory = { id: "", title: "", value: "" };
   }
 
 
@@ -75,24 +79,25 @@ export default class ChatHistory {
     return this.history;
   }
 
-  getMemory(): Record<string, string> {
+  getMemory(): MemoryEntry {
     return this.memory;
   }
 
   getPrompt(): ChatEntry[] {
-    const memoryEntries: ChatEntry[] = Object.entries(this.memory).map(
-      ([key, value]) => ({
+    const memoryEntries: ChatEntry[] = [
+      {
         role: 'user',
-        parts: [{ text: `${key}: ${value}` }],
-      })
-    );
+        parts: [{ text: `${this.memory.title}: ${this.memory.value}` }]
+      }
+    ];
 
-  if (this.isReplying) {
-  return [...memoryEntries, ...this.history, this.replyMessage];
+    if (this.isReplying) {
+      return [...memoryEntries, ...this.history, this.replyMessage];
     }
 
-  return [...memoryEntries, ...this.history];
-}
+    return [...memoryEntries, ...this.history];
+  }
+
 
   static async saveGlobalCounter(count: number) {
     const res = await fetch(`${FIREBASE_DB}/global_counter.json`, {

--- a/src/components/ChatSession/ChatHistory.ts
+++ b/src/components/ChatSession/ChatHistory.ts
@@ -26,7 +26,7 @@ export default class ChatHistory {
   private chatid: number = -1;
   private chattitle: string = '';
   private history: ChatEntry[] = [];
-  private memory: Record<string, string> = {"1": "[This is for your background information, you do not have to explcily reply it] mood: happy, name: xingye, home: Mars"};
+  private memory: Record<string, string> = {"1": "[This is for your background information, you do not have to explcily reply it, treat it as your memory about me] mood: happy, name: xingye, home: Mars"};
   private replyMessage: ChatEntry = { role: 'user', parts: [{ text: '' }] };
 
   setReplyMessage(message: string) {
@@ -59,7 +59,7 @@ export default class ChatHistory {
 
   //   Memory Management
   setMemory(key: string, value: string) {
-    this.memory[key] = "[This is for your background information, you do not have to explcily reply it] " + value;
+    this.memory[key] = "[This is for your background information, you do not have to explcily reply it, treat it as your memory about me] " + value;
   }
 
   deleteMemory(key: string) {

--- a/src/components/CreateChatPage/CreateChatDisplay.css
+++ b/src/components/CreateChatPage/CreateChatDisplay.css
@@ -104,8 +104,14 @@
   margin-top: 18px;
 }
 
+.form-actions text {
+  color: #000000;
+  font-size: 16px;
+  font-weight: 500;
+}
+
 .create-chat-btn {
-  background: #E2E7D3;
+  background: #b7c6a4;
   color: #fff;
   border-radius: 8px;
   padding: 10px 28px;

--- a/src/components/CreateChatPage/CreateChatDisplay.tsx
+++ b/src/components/CreateChatPage/CreateChatDisplay.tsx
@@ -116,7 +116,7 @@ export function CreateChatDisplay() {
             chatTitle,
             [],
             {
-                memoryID: memoryContent ?? ""
+                memoryName: memoryContent ?? ""
             }
         );
         await newChat.saveToFirebase();

--- a/src/components/CreateChatPage/CreateChatDisplay.tsx
+++ b/src/components/CreateChatPage/CreateChatDisplay.tsx
@@ -5,6 +5,7 @@ import { NavBar } from '../TopBar/NavBar.js'
 import type { Memory, Folder, Chat } from '../../data/types.ts';
 import { defaultMemory } from '../MemoryPage/MemoryDisplay.js';
 import ChatHistory from '../ChatSession/ChatHistory.js';
+import { useNavigation } from '../NavigationContext.js';
 
 import { FIREBASE_DB } from '../../Env.js'
 
@@ -16,6 +17,8 @@ export function CreateChatDisplay() {
     const [memoryDropdown, setMemoryDropdown] = useState(false)
     const [availableMemories, setAvailableMemories] = useState<Memory[]>([])
     const [availableFolders, setAvailableFolders] = useState<Folder[]>([])
+
+    const { navigate } = useNavigation();
 
     const loadMemoriesFromFirebase = async () => {
         let loadedMemories: Memory[] = [];
@@ -133,6 +136,7 @@ export function CreateChatDisplay() {
             });
         }
 
+        navigate('chatdisplay', { chatID: chatID.toString() });
     }
 
     return (

--- a/src/components/CreateChatPage/CreateChatDisplay.tsx
+++ b/src/components/CreateChatPage/CreateChatDisplay.tsx
@@ -116,7 +116,9 @@ export function CreateChatDisplay() {
             chatTitle,
             [],
             {
-                memoryName: memoryContent ?? ""
+                id: memoryID ?? "0",
+                title: memoryName ?? "",
+                value: memoryContent ?? ""
             }
         );
         await newChat.saveToFirebase();

--- a/src/components/MemoryPage/MemoryDisplay.tsx
+++ b/src/components/MemoryPage/MemoryDisplay.tsx
@@ -14,7 +14,7 @@ import { NavBar } from '../TopBar/NavBar.js'
 
 import { FIREBASE_DB } from '../../Env.js'
 
-const defaultMemory = {
+export const defaultMemory = {
   memoryID: '1',
   memoryName: 'Default Memory',
   content: 'This is the content of your memory. You can edit its content or delete it if you wish.',

--- a/src/components/NavigationContext.tsx
+++ b/src/components/NavigationContext.tsx
@@ -3,13 +3,15 @@
 import { createContext, useState, useContext } from '@lynx-js/react';
 import type { ReactNode } from '@lynx-js/react';
 
-// 1. Define interface
+// 1. Define interface with params support
 interface NavigationContextType {
   currentPage: string;
+  params: any;
   setCurrentPage: (page: string) => void;
+  navigate: (page: string, params?: any) => void;
 }
 
-// 2. Create context, with the interface as a generic type parameter
+// 2. Create context
 const NavigationContext = createContext<NavigationContextType | null>(null);
 
 // 3. Create a custom hook
@@ -28,7 +30,19 @@ interface NavigationProviderProps {
 
 export const NavigationProvider: React.FC<NavigationProviderProps> = ({ children }) => {
   const [currentPage, setCurrentPage] = useState('home');
-  const value: NavigationContextType = { currentPage, setCurrentPage };
+  const [params, setParams] = useState<any>(null);
+
+  const navigate = (page: string, newParams?: any) => {
+    setCurrentPage(page);
+    setParams(newParams || null);
+  };
+
+  const value: NavigationContextType = { 
+    currentPage, 
+    params, 
+    setCurrentPage, 
+    navigate 
+  };
 
   return (
     <NavigationContext.Provider value={value}>
@@ -36,4 +50,3 @@ export const NavigationProvider: React.FC<NavigationProviderProps> = ({ children
     </NavigationContext.Provider>
   );
 };
-

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -29,3 +29,10 @@ export interface Memory {
 export interface MemoryData {
   memories: Memory[];
 }
+
+// Define the structure of a single folder object
+export interface Folder {
+  folderID: string;
+  folderName: string;
+  chats: Chat[];
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,13 +25,14 @@ function SafeAreaWrapper({ children }: { children: ReactNode }) {
 
 function MainApp() {
   // Use the hook to get the state from the NavigationProvider
-  const { currentPage } = useNavigation();
+  const { currentPage, params } = useNavigation();
   
   // The rest of your logic remains the same, but without the need for setCurrentPage
   if (currentPage === 'home') {
     return <App />; // No more onNavigateTo prop
   } else if (currentPage === 'chatdisplay') {
-    return <ChatDisplay chatID="chat-1" />; // No more setCurrentPage prop
+    const chatID = params?.chatID || "1";
+    return <ChatDisplay chatID={chatID} />;
   } else if (currentPage === 'memory') {
     return <Memory />;
   } else if (currentPage === 'chatsession') {


### PR DESCRIPTION
Upon creating a chat:
- chat collection in firebase is updated with new chat (new chat has memory field but no history field) 
<img width="283" height="330" alt="image" src="https://github.com/user-attachments/assets/0fdc780e-2454-4691-8237-8fab75a456e0" />

- global counter is incremented
- folder collection in firebase is updated with the chatid and chat title
- user will be navigated to the chatdisplay page with the new chat